### PR TITLE
Fix UI block during scan

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -22,7 +22,7 @@ jobs:
         ref: ${{ inputs.ref }}
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
       with:
         vs-version: 'latest'
 

--- a/JFrogVSExtension/JFrogVSExtension.csproj
+++ b/JFrogVSExtension/JFrogVSExtension.csproj
@@ -248,10 +248,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0">
       <Version>17.1.32210.191</Version>
     </PackageReference>
-    <!-- 
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0">
-      <Version>17.12.40391</Version>
-    </PackageReference>  -->
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>17.12.2069</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/JFrogVSExtension/JFrogVSExtension.csproj
+++ b/JFrogVSExtension/JFrogVSExtension.csproj
@@ -59,8 +59,8 @@
     </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>2</WarningLevel>
-	<IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
-	<IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
+    <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
+    <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
@@ -247,6 +247,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0">
       <Version>17.1.32210.191</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0">
+      <Version>17.12.40391</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>17.1.4054</Version>

--- a/JFrogVSExtension/JFrogVSExtension.csproj
+++ b/JFrogVSExtension/JFrogVSExtension.csproj
@@ -248,9 +248,10 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0">
       <Version>17.1.32210.191</Version>
     </PackageReference>
+	  <!-- 
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0">
       <Version>17.12.40391</Version>
-    </PackageReference>
+    </PackageReference>  -->
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>17.1.4054</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/JFrogVSExtension/JFrogVSExtension.csproj
+++ b/JFrogVSExtension/JFrogVSExtension.csproj
@@ -238,22 +238,22 @@
       <Version>17.1.32210.191</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Interop">
-      <Version>17.1.32210.191</Version>
+      <Version>17.12.40391</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers">
-      <Version>16.10.10</Version>
+      <Version>17.7.47</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0">
       <Version>17.1.32210.191</Version>
     </PackageReference>
-	  <!-- 
+    <!-- 
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0">
       <Version>17.12.40391</Version>
     </PackageReference>  -->
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.1.4054</Version>
+      <Version>17.12.2069</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/JFrogVSExtension/MainPanelControl.xaml.cs
+++ b/JFrogVSExtension/MainPanelControl.xaml.cs
@@ -148,7 +148,7 @@
         {
             if (isAllFilterChecked)
             {
-                InitCheckbox(); 
+                InitCheckbox();
             }
         }
 

--- a/JFrogVSExtension/MainPanelControl.xaml.cs
+++ b/JFrogVSExtension/MainPanelControl.xaml.cs
@@ -133,7 +133,7 @@
             {
                 InitCheckbox();
             }
-            await ((MainViewModel)this.DataContext).LoadAsync();
+            //await ((MainViewModel)this.DataContext).LoadAsync(); TODO: remove if works
         }
 
         private void InitCheckbox()
@@ -153,7 +153,7 @@
             {
                 InitCheckbox();
             }
-            await ((MainViewModel)this.DataContext).LoadAsync();
+            //await ((MainViewModel)this.DataContext).LoadAsync(); TODO: uncomment this line if needed
         }
 
         public async Task CloseAsync()

--- a/JFrogVSExtension/MainPanelControl.xaml.cs
+++ b/JFrogVSExtension/MainPanelControl.xaml.cs
@@ -125,15 +125,12 @@
         {
         }
 
-#pragma warning disable VSTHRD100 // Avoid async void methods - Signature expected by event handler.
-        private async void Tree_Loaded(object sender, RoutedEventArgs e)
-#pragma warning restore VSTHRD100 // Avoid async void methods
+        private void Tree_Loaded(object sender, RoutedEventArgs e)
         {
             if (isAllFilterChecked)
             {
                 InitCheckbox();
             }
-            //await ((MainViewModel)this.DataContext).LoadAsync(); TODO: remove if works
         }
 
         private void InitCheckbox()
@@ -151,9 +148,8 @@
         {
             if (isAllFilterChecked)
             {
-                InitCheckbox();
+                InitCheckbox(); 
             }
-            //await ((MainViewModel)this.DataContext).LoadAsync(); TODO: uncomment this line if needed
         }
 
         public async Task CloseAsync()

--- a/JFrogVSExtension/UI/MainPanel/MainPanelPackage.cs
+++ b/JFrogVSExtension/UI/MainPanel/MainPanelPackage.cs
@@ -92,6 +92,7 @@ namespace JFrogVSExtension
 
         protected override void Dispose(bool disposing)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             if (_solutionEventsCookie != 0)
             {
                 _solution.UnadviseSolutionEvents(_solutionEventsCookie);

--- a/JFrogVSExtension/UI/Panel/DataService.cs
+++ b/JFrogVSExtension/UI/Panel/DataService.cs
@@ -130,8 +130,10 @@ namespace JFrogVSExtension.Data
         public async Task<Artifacts> GetSecurityIssuesAsync(bool reScan, Projects projects, string solutionDir)
         {
             var componentsSet = new HashSet<Components>();
-            var workingDirs = new List<string>();
-            workingDirs.Add(solutionDir);
+            var workingDirs = new List<string>
+            {
+                solutionDir
+            };
             if (!reScan)
             {
                 foreach (Project project in projects.All)

--- a/JFrogVSExtension/UI/Panel/Tree/TreeViewModel.cs
+++ b/JFrogVSExtension/UI/Panel/Tree/TreeViewModel.cs
@@ -85,7 +85,7 @@ namespace JFrogVSExtension.Tree
                 // 4. Get response and build the dependencies tree.
 
                 // Running CLI - this is the returned output.
-                String returnedText = await Task.Run(() => Util.GetCLIOutputAsync("rt nuget-deps-tree",solutionDir));
+                String returnedText = await Util.GetCLIOutputAsync("rt nuget-deps-tree",solutionDir);
                 
                 // Load projects from output.
                 Project[] nugetProjects = Util.LoadNugetProjects(returnedText);

--- a/JFrogVSExtension/Utils/ScanManager/ScanManager.cs
+++ b/JFrogVSExtension/Utils/ScanManager/ScanManager.cs
@@ -46,7 +46,7 @@ namespace JFrogVSExtension.Utils.ScanManager
         public async Task<string> PreformScanAsync(List<string> workingDirs)
         {
             var workingDirsString = workingDirs.Count() > 1 ? string.Join(", ", workingDirs) : workingDirs.First();
-            var cliAuditCommand = $"audit --format=\"json\" --server-id=\"{CliServerId}\" --licenses --fail=\"false\" --working-dirs=\"{workingDirsString}\"";
+            var cliAuditCommand = $"audit --sca --format=\"json\" --server-id=\"{CliServerId}\" --licenses --fail=\"false\" --working-dirs=\"{workingDirsString}\"";
 
             switch (Policy)
             {
@@ -57,7 +57,7 @@ namespace JFrogVSExtension.Utils.ScanManager
                     cliAuditCommand += $" --watches=\"{watches}\"";
                     break;
             }
-            return await  Util.GetCLIOutputAsync(cliAuditCommand, workingDirs.First(), false, cliEnv);
+            return await Util.GetCLIOutputAsync(cliAuditCommand, workingDirs.First(), false, cliEnv);
         }
     }
 }

--- a/JFrogVSExtension/Utils/Util.cs
+++ b/JFrogVSExtension/Utils/Util.cs
@@ -2,7 +2,6 @@
 using JFrogVSExtension.Logger;
 using JFrogVSExtension.Xray;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using Newtonsoft.Json;
 using System;
@@ -119,14 +118,6 @@ namespace JFrogVSExtension.Utils
 
         public static async Task<string> GetProcessOutputAsync(string pathToExe, string command, string workingDir = "", bool configCommand = false, Dictionary<string, string> envVars = null)
         {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            IVsStatusbar statusBar = (IVsStatusbar)Package.GetGlobalService(typeof(SVsStatusbar));
-            uint cookie = 0;
-
-            // Display "Scan in progress" message
-            statusBar.SetText("Scan in progress...");
-            statusBar.Progress(ref cookie, 1, "", 0, 0);
-
             return await Task.Run(async () =>
             {
                 //Create process

--- a/JFrogVSExtension/Utils/Util.cs
+++ b/JFrogVSExtension/Utils/Util.cs
@@ -57,17 +57,9 @@ namespace JFrogVSExtension.Utils
 
                 var npmProj = JsonConvert.DeserializeObject<NpmLsNode>(npmProjectTree.Result);
 
-                //JoinableTaskFactory joinableTaskFactory = new JoinableTaskFactory(ThreadHelper.JoinableTaskContext);
-
-                //var npmProj = joinableTaskFactory.Run(async () =>
-                //{
-                //    return await GetProcessOutputAsync("cmd.exe", "/C npm ls --json --all --long --package-lock-only", fileInfo.DirectoryName);
-                //});
-
-
                 var project = new Project()
                 {
-                    name = $"{npmProj.name}:{npmProj.version}", 
+                    name = $"{npmProj.name}:{npmProj.version}",
                     directoryPath = fileInfo.DirectoryName,
                     dependencies = new Dependency[] { },
                 };
@@ -115,13 +107,13 @@ namespace JFrogVSExtension.Utils
             var strFilePath = Path.Combine(strAppPath, "Resources");
             var pathToCli = Path.Combine(strFilePath, "jfrog.exe");
             await OutputLog.ShowMessageAsync("Path for the JFrog CLI: " + pathToCli);
-            return await Task.Run(async () => await GetProcessOutputAsync(pathToCli, command, workingDir, configCommand, envVars));
+            return await GetProcessOutputAsync(pathToCli, command, workingDir, configCommand, envVars);
         }
 
         public static async Task<string> GetProcessOutputAsync(string pathToExe, string command, string workingDir = "", bool configCommand = false, Dictionary<string, string> envVars = null)
         {
-            //return await Task.Run(async () =>
-            //{
+            return await Task.Run(async () =>
+            {
                 //Create process
                 Process pProcess = new Process
                 {
@@ -217,7 +209,7 @@ namespace JFrogVSExtension.Utils
                     await OutputLog.ShowMessageAsync("Process timeout");
                     throw new IOException($"Process timeout,  {pathToExe} {commandString}");
                 }
-            //});
+            });
         }
 
         private static string GetAssemblyLocalPathFrom(Type type)

--- a/JFrogVSExtension/source.extension.vsixmanifest
+++ b/JFrogVSExtension/source.extension.vsixmanifest
@@ -1,25 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="JFrogVSExtension.c07afb03-9f9a-45e2-8e6f-78442325bb24" Version="2.1.1" Language="en-US" Publisher="JFrog" />
-    <DisplayName>JFrog V2</DisplayName>
-    <Description xml:space="preserve">Visual Studio extension to integrate with JFrog Xray for scanning solution components. </Description>
-    <Icon>Resources\Icon.png</Icon>
-    <PreviewImage>Resources\PreviewImage.png</PreviewImage>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.ToolboxControl" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="JFrogVSExtension.c07afb03-9f9a-45e2-8e6f-78442325bb24" Version="2.1.2" Language="en-US" Publisher="JFrog" />
+        <DisplayName>JFrog V2</DisplayName>
+        <Description xml:space="preserve">Visual Studio extension to integrate with JFrog Xray for scanning solution components. </Description>
+        <Icon>Resources\Icon.png</Icon>
+        <PreviewImage>Resources\PreviewImage.png</PreviewImage>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.ToolboxControl" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] All [tests](https://github.com/jfrog/jfrog-visual-studio-extension/actions/workflows/tests.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
- Fixed bug that caused UI block during scan.
- Cancel auto scan when loading the Jfrog extension tool panel. Scan will be performed only by clicking the refresh button.
- Updated project dependencies to fix build issues in the build workflow.
- Changed the audit command to scan only SCA in order to decrease scan process duration.