### PR TITLE
Adjust release automation for building and publishing the extension

### DIFF
--- a/.github/actions/build-vsix/action.yml
+++ b/.github/actions/build-vsix/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: Build VSIX Project 
       shell: powershell
       run: |
-        msbuild JFrogVSExtension.sln /p:Configuration=Release /p:Platform="Any CPU" /p:BuildInParallel=true /m
+        msbuild JFrogVSExtension.sln /p:Configuration=Release /p:Platform="Any CPU"
 
     - name: Check for PDB in VSIX
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
       # upload the vsix and manifest files to Visual Studio Marketplace using VsixPublisher
       - name: Publish to Visual Studio Marketplace
-         vsix publisher executable is already installed in the github windows runner at the following path
+         # vsix publisher executable is already installed in the github windows runner at the following path
         run: |
           $VSIX_PUBLISHER_PATH = "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VSSDK/VisualStudioIntegration/Tools/Bin/VsixPublisher.exe"
           $VSIX_PATH = "./JFrogVSExtension/bin/Release/JFrogVSExtension.vsix"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build VSIX Project
         uses: ./.github/actions/build-vsix
         with: 
-           ref: master
+           ref: ${{ github.event.release.target_commitish }}
            vs-version: latest
 
       # download build workflow artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,32 @@ on:
 
 jobs:
 
-  release:
+  build_and_publish:
     runs-on: windows-latest
-    needs: call-build-workflow
+    env:
+        NEW_VERSION: '${{ github.ref_name }}' 
+        MANIFEST_FILE_LOCATION: "JfrogVSExtension/source.extension.vsixmanifest"
+
     steps:
+      - name: Config Github
+        run: |
+            git config --global user.name "${{ github.actor }}"
+            git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with: 
+            ref: ${{ github.event.release.target_commitish }}
+
+      - name: Update VSIX Version in manifest file
+        run: .\scripts\UpdateVsixVersion.ps1
+        shell: pwsh
+
+      - name: Commit and push changes
+        run: |
+            git add .
+            git commit -m "Updated VSIX version to ${{ env.NEW_VERSION }}"
+            git push
 
       # build and package the vsix project
       - name: Build VSIX Project
@@ -37,11 +59,17 @@ jobs:
           asset_content_type: application/octet-stream
 
       # upload the vsix and manifest files to Visual Studio Marketplace using VsixPublisher
-      - name: Publish to Visual Studio Marketplace
-         # vsix publisher executable is already installed in the github windows runner at the following path
+      # - name: Publish to Visual Studio Marketplace
+      #    vsix publisher executable is already installed in the github windows runner at the following path
+      #   run: |
+      #     $VSIX_PUBLISHER_PATH = "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VSSDK/VisualStudioIntegration/Tools/Bin/VsixPublisher.exe"
+      #     $VSIX_PATH = "./JFrogVSExtension/bin/Release/JFrogVSExtension.vsix"
+      #     $PUBLISH_MANIFEST_PATH = "./JFrogVSExtension/PublishManifest.json"
+      #     & $VSIX_PUBLISHER_PATH publish -payload $VSIX_PATH -publishManifest $PUBLISH_MANIFEST_PATH -personalAccessToken ${{ secrets.VS_MARKETPLACE_PAT }}
+      #   shell: pwsh
+
+      - name: Rebase dev onto master
         run: |
-          $VSIX_PUBLISHER_PATH = "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VSSDK/VisualStudioIntegration/Tools/Bin/VsixPublisher.exe"
-          $VSIX_PATH = "./JFrogVSExtension/bin/Release/JFrogVSExtension.vsix"
-          $PUBLISH_MANIFEST_PATH = "./JFrogVSExtension/PublishManifest.json"
-          & $VSIX_PUBLISHER_PATH publish -payload $VSIX_PATH -publishManifest $PUBLISH_MANIFEST_PATH -personalAccessToken ${{ secrets.VS_MARKETPLACE_PAT }}
-        shell: pwsh
+            git checkout dev
+            git rebase master
+            git push origin dev --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Rebase dev onto master
         run: |
+            git fetch --all
             git checkout dev
             git rebase master
             git push origin dev --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
 
       # download build workflow artifacts
       - name: Download VSIX artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
         # use the unique artifact name from the build action
             name: vsix-artifacts-latest-${{ github.run_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,14 +59,14 @@ jobs:
           asset_content_type: application/octet-stream
 
       # upload the vsix and manifest files to Visual Studio Marketplace using VsixPublisher
-      # - name: Publish to Visual Studio Marketplace
-      #    vsix publisher executable is already installed in the github windows runner at the following path
-      #   run: |
-      #     $VSIX_PUBLISHER_PATH = "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VSSDK/VisualStudioIntegration/Tools/Bin/VsixPublisher.exe"
-      #     $VSIX_PATH = "./JFrogVSExtension/bin/Release/JFrogVSExtension.vsix"
-      #     $PUBLISH_MANIFEST_PATH = "./JFrogVSExtension/PublishManifest.json"
-      #     & $VSIX_PUBLISHER_PATH publish -payload $VSIX_PATH -publishManifest $PUBLISH_MANIFEST_PATH -personalAccessToken ${{ secrets.VS_MARKETPLACE_PAT }}
-      #   shell: pwsh
+      - name: Publish to Visual Studio Marketplace
+         vsix publisher executable is already installed in the github windows runner at the following path
+        run: |
+          $VSIX_PUBLISHER_PATH = "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VSSDK/VisualStudioIntegration/Tools/Bin/VsixPublisher.exe"
+          $VSIX_PATH = "./JFrogVSExtension/bin/Release/JFrogVSExtension.vsix"
+          $PUBLISH_MANIFEST_PATH = "./JFrogVSExtension/PublishManifest.json"
+          & $VSIX_PUBLISHER_PATH publish -payload $VSIX_PATH -publishManifest $PUBLISH_MANIFEST_PATH -personalAccessToken ${{ secrets.VS_MARKETPLACE_PAT }}
+        shell: pwsh
 
       - name: Rebase dev onto master
         run: |

--- a/JFrogVSExtension/source.extension.vsixmanifest
+++ b/JFrogVSExtension/source.extension.vsixmanifest
@@ -1,25 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="JFrogVSExtension.c07afb03-9f9a-45e2-8e6f-78442325bb24" Version="1.2.3" Language="en-US" Publisher="JFrog" />
-    <DisplayName>JFrog V2</DisplayName>
-    <Description xml:space="preserve">Visual Studio extension to integrate with JFrog Xray for scanning solution components. </Description>
-    <Icon>Resources\Icon.png</Icon>
-    <PreviewImage>Resources\PreviewImage.png</PreviewImage>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.ToolboxControl" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="JFrogVSExtension.c07afb03-9f9a-45e2-8e6f-78442325bb24" Version="2.1.2" Language="en-US" Publisher="JFrog" />
+        <DisplayName>JFrog V2</DisplayName>
+        <Description xml:space="preserve">Visual Studio extension to integrate with JFrog Xray for scanning solution components. </Description>
+        <Icon>Resources\Icon.png</Icon>
+        <PreviewImage>Resources\PreviewImage.png</PreviewImage>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.ToolboxControl" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>

--- a/JFrogVSExtension/source.extension.vsixmanifest
+++ b/JFrogVSExtension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="JFrogVSExtension.c07afb03-9f9a-45e2-8e6f-78442325bb24" Version="2.1.3" Language="en-US" Publisher="JFrog" />
+    <Identity Id="JFrogVSExtension.c07afb03-9f9a-45e2-8e6f-78442325bb24" Version="2.1.2" Language="en-US" Publisher="JFrog" />
     <DisplayName>JFrog V2</DisplayName>
     <Description xml:space="preserve">Visual Studio extension to integrate with JFrog Xray for scanning solution components. </Description>
     <Icon>Resources\Icon.png</Icon>

--- a/JFrogVSExtension/source.extension.vsixmanifest
+++ b/JFrogVSExtension/source.extension.vsixmanifest
@@ -1,25 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="JFrogVSExtension.c07afb03-9f9a-45e2-8e6f-78442325bb24" Version="2.1.2" Language="en-US" Publisher="JFrog" />
-    <DisplayName>JFrog V2</DisplayName>
-    <Description xml:space="preserve">Visual Studio extension to integrate with JFrog Xray for scanning solution components. </Description>
-    <Icon>Resources\Icon.png</Icon>
-    <PreviewImage>Resources\PreviewImage.png</PreviewImage>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.ToolboxControl" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+	<Metadata>
+		<Identity Id="JFrogVSExtension.c07afb03-9f9a-45e2-8e6f-78442325bb24" Version="2.1.2" Language="en-US" Publisher="JFrog" />
+		<DisplayName>JFrog V2</DisplayName>
+		<Description xml:space="preserve">Visual Studio extension to integrate with JFrog Xray for scanning solution components. </Description>
+		<Icon>Resources\Icon.png</Icon>
+		<PreviewImage>Resources\PreviewImage.png</PreviewImage>
+	</Metadata>
+	<Installation>
+		<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+			<ProductArchitecture>amd64</ProductArchitecture>
+		</InstallationTarget>
+	</Installation>
+	<Dependencies>
+		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+	</Dependencies>
+	<Prerequisites>
+		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+	</Prerequisites>
+	<Assets>
+		<Asset Type="Microsoft.VisualStudio.ToolboxControl" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+	</Assets>
 </PackageManifest>

--- a/JFrogVSExtension/source.extension.vsixmanifest
+++ b/JFrogVSExtension/source.extension.vsixmanifest
@@ -1,25 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="JFrogVSExtension.c07afb03-9f9a-45e2-8e6f-78442325bb24" Version="2.1.2" Language="en-US" Publisher="JFrog" />
-        <DisplayName>JFrog V2</DisplayName>
-        <Description xml:space="preserve">Visual Studio extension to integrate with JFrog Xray for scanning solution components. </Description>
-        <Icon>Resources\Icon.png</Icon>
-        <PreviewImage>Resources\PreviewImage.png</PreviewImage>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-            <ProductArchitecture>amd64</ProductArchitecture>
-        </InstallationTarget>
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    </Dependencies>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.ToolboxControl" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    </Assets>
+  <Metadata>
+    <Identity Id="JFrogVSExtension.c07afb03-9f9a-45e2-8e6f-78442325bb24" Version="6.6.6" Language="en-US" Publisher="JFrog" />
+    <DisplayName>JFrog V2</DisplayName>
+    <Description xml:space="preserve">Visual Studio extension to integrate with JFrog Xray for scanning solution components. </Description>
+    <Icon>Resources\Icon.png</Icon>
+    <PreviewImage>Resources\PreviewImage.png</PreviewImage>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.ToolboxControl" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+  </Assets>
 </PackageManifest>

--- a/JFrogVSExtension/source.extension.vsixmanifest
+++ b/JFrogVSExtension/source.extension.vsixmanifest
@@ -1,25 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="JFrogVSExtension.c07afb03-9f9a-45e2-8e6f-78442325bb24" Version="2.1.2" Language="en-US" Publisher="JFrog" />
-        <DisplayName>JFrog V2</DisplayName>
-        <Description xml:space="preserve">Visual Studio extension to integrate with JFrog Xray for scanning solution components. </Description>
-        <Icon>Resources\Icon.png</Icon>
-        <PreviewImage>Resources\PreviewImage.png</PreviewImage>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-            <ProductArchitecture>amd64</ProductArchitecture>
-        </InstallationTarget>
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    </Dependencies>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.ToolboxControl" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    </Assets>
+  <Metadata>
+    <Identity Id="JFrogVSExtension.c07afb03-9f9a-45e2-8e6f-78442325bb24" Version="2.1.3" Language="en-US" Publisher="JFrog" />
+    <DisplayName>JFrog V2</DisplayName>
+    <Description xml:space="preserve">Visual Studio extension to integrate with JFrog Xray for scanning solution components. </Description>
+    <Icon>Resources\Icon.png</Icon>
+    <PreviewImage>Resources\PreviewImage.png</PreviewImage>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.ToolboxControl" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+  </Assets>
 </PackageManifest>

--- a/JFrogVSExtension/source.extension.vsixmanifest
+++ b/JFrogVSExtension/source.extension.vsixmanifest
@@ -1,25 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="JFrogVSExtension.c07afb03-9f9a-45e2-8e6f-78442325bb24" Version="6.6.6" Language="en-US" Publisher="JFrog" />
-    <DisplayName>JFrog V2</DisplayName>
-    <Description xml:space="preserve">Visual Studio extension to integrate with JFrog Xray for scanning solution components. </Description>
-    <Icon>Resources\Icon.png</Icon>
-    <PreviewImage>Resources\PreviewImage.png</PreviewImage>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.ToolboxControl" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="JFrogVSExtension.c07afb03-9f9a-45e2-8e6f-78442325bb24" Version="2.1.2" Language="en-US" Publisher="JFrog" />
+        <DisplayName>JFrog V2</DisplayName>
+        <Description xml:space="preserve">Visual Studio extension to integrate with JFrog Xray for scanning solution components. </Description>
+        <Icon>Resources\Icon.png</Icon>
+        <PreviewImage>Resources\PreviewImage.png</PreviewImage>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.ToolboxControl" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] All [tests](https://github.com/jfrog/jfrog-visual-studio-extension/actions/workflows/tests.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
- Added automation for updating vsixmanifest file with the new version according to release note, building the extension in release mode and publishing it to Visual Studio marketplace.
- Change build parameters to not run in parallel to avoid conflicts.