### PR TITLE
Fix release workflow Marketplace publish failure

### DIFF
--- a/JFrogVSExtension/PublishManifest.json
+++ b/JFrogVSExtension/PublishManifest.json
@@ -2,8 +2,7 @@
     "$schema": "http://json.schemastore.org/vsix-publish",
     "categories": [ "build", "coding" ], // The categories of the extension. Between 1 and 3 categories are required.
     "identity": {
-        "internalName": "JFrog V2" // If not specified, we try to generate the name from the display name of the extension in the vsixmanifest file.
-        // Required if the display name is not the actual name of the extension.
+        "internalName": "JFrogV2" // Must match Marketplace item JFrog.JFrogV2 (not DisplayName; VsixPub0033 rejects spaces).
     },
     "overview": "../README.md", // Path to the "readme" file that gets uploaded to the Marketplace. Required.
     "priceCategory": "free", // Either "free", "trial", or "paid". Defaults to "free".


### PR DESCRIPTION
## Summary

Fixes failed `vs22-2.1.6` Marketplace publish ([run 27189242182](https://github.com/jfrog/jfrog-visual-studio-extension/actions/runs/27189242182)):

- **`PublishManifest.json`**: `internalName` → `JFrogV2` (matches listing `JFrog.JFrogV2`; fixes `VsixPub0033`)

No workflow changes. No rebuild required — the GitHub release VSIX is fine.

## After merge (one-time before re-run)

1. Merge to `dev`, then get onto `master`
2. **Delete** `JFrogVSExtension.vsix` from the [vs22-2.1.6 release](https://github.com/jfrog/jfrog-visual-studio-extension/releases/tag/vs22-2.1.6) (one-time — clears the duplicate-asset failure on re-run)
3. Re-run the release workflow
4. Confirm [Marketplace](https://marketplace.visualstudio.com/items?itemName=JFrog.JFrogV2) shows **2.1.6**