### PR TITLE
Fix PublishManifest for vs22-2.1.6 release

### DIFF
--- a/JFrogVSExtension/PublishManifest.json
+++ b/JFrogVSExtension/PublishManifest.json
@@ -2,8 +2,7 @@
     "$schema": "http://json.schemastore.org/vsix-publish",
     "categories": [ "build", "coding" ], // The categories of the extension. Between 1 and 3 categories are required.
     "identity": {
-        "internalName": "JFrog V2" // If not specified, we try to generate the name from the display name of the extension in the vsixmanifest file.
-        // Required if the display name is not the actual name of the extension.
+        "internalName": "JFrogV2" // Must match Marketplace item JFrog.JFrogV2 (not DisplayName; VsixPub0033 rejects spaces).
     },
     "overview": "../README.md", // Path to the "readme" file that gets uploaded to the Marketplace. Required.
     "priceCategory": "free", // Either "free", "trial", or "paid". Defaults to "free".


### PR DESCRIPTION
## Summary
Cherry-pick of #62 onto `master` so the pending **vs22-2.1.6** release (Or's jfrog-cli 2.107.0 bump) can publish to Marketplace.

Fixes `VsixPub0033` — `internalName` must be `JFrogV2`, not `JFrog V2`.

No other changes.

## After merge
Recreate/publish the `vs22-2.1.6` GitHub release from `master` to trigger the release workflow (a re-run of the old failed workflow uses the pre-fix commit).

Made with [Cursor](https://cursor.com)