### PR TITLE
Fix VsixPublisher path for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,20 @@ jobs:
 
       # upload the vsix and manifest files to Visual Studio Marketplace using VsixPublisher
       - name: Publish to Visual Studio Marketplace
-         # vsix publisher executable is already installed in the github windows runner at the following path
         run: |
-          $VSIX_PUBLISHER_PATH = "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VSSDK/VisualStudioIntegration/Tools/Bin/VsixPublisher.exe"
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          if (-not (Test-Path $vswhere)) {
+            throw "vswhere.exe not found at $vswhere"
+          }
+          $installPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VSSDK -property installationPath
+          if (-not $installPath) {
+            throw "No Visual Studio installation with VSSDK found on this runner."
+          }
+          $VSIX_PUBLISHER_PATH = Join-Path $installPath 'VSSDK\VisualStudioIntegration\Tools\Bin\VsixPublisher.exe'
+          if (-not (Test-Path $VSIX_PUBLISHER_PATH)) {
+            throw "VsixPublisher.exe not found at $VSIX_PUBLISHER_PATH"
+          }
+          Write-Host "Using VsixPublisher: $VSIX_PUBLISHER_PATH"
           $VSIX_PATH = "./JFrogVSExtension/bin/Release/JFrogVSExtension.vsix"
           $PUBLISH_MANIFEST_PATH = "./JFrogVSExtension/PublishManifest.json"
           & $VSIX_PUBLISHER_PATH publish -payload $VSIX_PATH -publishManifest $PUBLISH_MANIFEST_PATH -personalAccessToken ${{ secrets.VS_MARKETPLACE_PAT }}


### PR DESCRIPTION
## Summary
`windows-latest` runners no longer have VS at `...\2022\Enterprise\...` (VS 2026 layout). Marketplace publish failed because `VsixPublisher.exe` was not found.

Use `vswhere` with `Microsoft.VisualStudio.Component.VSSDK` to resolve the install path dynamically.

## After merge
Recreate `vs22-2.1.6` release from `master` to complete Or's pending publish (delete existing release asset first if needed).

Made with [Cursor](https://cursor.com)